### PR TITLE
Replace `xacro.py` to `xacro --inorder`

### DIFF
--- a/dependencies/ur_description/launch/ur10_upload.launch
+++ b/dependencies/ur_description/launch/ur10_upload.launch
@@ -2,6 +2,6 @@
 <launch>
   <arg name="limited" default="false"/>
   
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
 </launch>

--- a/dependencies/ur_description/launch/ur5_upload.launch
+++ b/dependencies/ur_description/launch/ur5_upload.launch
@@ -2,6 +2,6 @@
 <launch>
   <arg name="limited" default="false"/>
   
-  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
-  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
+  <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
+  <param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
 </launch>

--- a/ur_driver/launch/ur10_real.launch
+++ b/ur_driver/launch/ur10_real.launch
@@ -8,9 +8,9 @@
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
 
 
-	<param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
+	<param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
 
-	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
+	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
 
 
 	<!-- load configuration -->

--- a/ur_driver/launch/ur10_sim.launch
+++ b/ur_driver/launch/ur10_sim.launch
@@ -8,9 +8,9 @@
 	<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
 
 
-	<param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
+	<param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_robot.urdf.xacro'" />
 
-	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
+	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur10_joint_limited_robot.urdf.xacro'" />
 
 
 	<!-- load configuration -->

--- a/ur_driver/launch/ur5_real.launch
+++ b/ur_driver/launch/ur5_real.launch
@@ -3,10 +3,10 @@
     <arg name="limited" default="false"/>
 
     <!-- load robot model -->
-    <!--<param name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/cells/ipa325_ur5_empty.urdf.xacro'" />-->
-   	<param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
+    <!--<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/cells/ipa325_ur5_empty.urdf.xacro'" />-->
+   	<param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
 
-	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
+	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
 
     <!-- start robot state publisher -->
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />

--- a/ur_driver/launch/ur5_sim.launch
+++ b/ur_driver/launch/ur5_sim.launch
@@ -3,10 +3,10 @@
     <arg name="limited" default="false"/>
 
     <!-- load robot model -->
-    <!--<param name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/cells/ipa325_ur5_empty.urdf.xacro'" />-->
-    <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
+    <!--<param name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/cells/ipa325_ur5_empty.urdf.xacro'" />-->
+    <param unless="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_robot.urdf.xacro'" />
 
-	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro.py '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
+	<param if="$(arg limited)" name="robot_description" command="$(find xacro)/xacro --inorder '$(find ur_description)/urdf/ur5_joint_limited_robot.urdf.xacro'" />
 
     <!-- start robot state publisher -->
     <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />


### PR DESCRIPTION
This PR fixes https://github.com/ros-industrial/industrial_training/issues/220 issue.

Environment:
- OS: Ubuntu 16.04
- ROS: Kinetic